### PR TITLE
Fix total k-mer order error

### DIFF
--- a/log_reg_case.R
+++ b/log_reg_case.R
@@ -14,7 +14,9 @@ input <- read.table("gwas_eigenstratX.ind");
 Y <- matrix(nrow=nrow(Z),ncol=1);
 cov <- matrix(nrow=nrow(Z),ncol=1);
 
-totals <- read.table("total_kmer_counts.txt");
+case_counts <- read.table("case_total_kmers.txt", header=FALSE)
+control_counts <- read.table("control_total_kmers.txt", header=FALSE)
+totals <- rbind(case_counts, control_counts)
 
 counts<- vector(length=length(Y));
 

--- a/log_reg_control.R
+++ b/log_reg_control.R
@@ -14,7 +14,9 @@ input <- read.table("gwas_eigenstratX.ind");
 Y <- matrix(nrow=nrow(Z),ncol=1);
 cov <- matrix(nrow=nrow(Z),ncol=1);
 
-totals <- read.table("total_kmer_counts.txt");
+case_counts <- read.table("case_total_kmers.txt", header=FALSE)
+control_counts <- read.table("control_total_kmers.txt", header=FALSE)
+totals <- rbind(case_counts, control_counts)
 
 counts<- vector(length=length(Y));
 


### PR DESCRIPTION
Currently the Rscripts import a "total_kmer_counts.txt" as totals which is sorted alphabetically by label, and the *_out_w_bonf_top.kmerDiff files as kmercounts, sorted first by case/control then by label. Therefore:
```
for(i in 1:length(Y))
{
counts[i]=kmercounts[j,4+i]/totals[i,1];
}
```
is not dividing correctly across label ID.

To double check, I reran HAWK using a presorted input set and got different results than default from the master branch.

Therefore, I modified the Rscripts to bind the HAWK generated case_total_kmers.txt and control_total_kmers.txt meaning that the totals table is now in the same order.